### PR TITLE
Fixing Auth Issue When qop param falls at the end

### DIFF
--- a/lib/digest.js
+++ b/lib/digest.js
@@ -129,11 +129,17 @@ function parseAuthHeader(hdrValue) {
 
   pieces.algorithm = pieces.algorithm || 'MD5' ;
 
-  // this is kind of lame...nc= at the end fails the regex above, should figure out how to fix that
+  // this is kind of lame...nc= (or qop=) at the end fails the regex above, should figure out how to fix that
   if (!pieces.nc && /nc=/.test(hdrValue)) {
     const arr = /nc=(.*)$/.exec(hdrValue) ;
     if (arr) {
       pieces.nc = arr[1];
+    }
+  }
+  if (!pieces.qop && /qop=/.test(hdrValue)) {
+    const arr = /qop=(.*)$/.exec(hdrValue) ;
+    if (arr) {
+      pieces.qop = arr[1];
     }
   }
 


### PR DESCRIPTION
If `qop=` falls at the end the regex fails. (similar to the hack you have with `nc=`