### PR TITLE
allow passwordLookup to handle precomputed hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,16 @@ const challenge = digestAuth({
 ### realm is optional, so what if I don't supply it?
 In that case, the challenge will use the domain in the Request-URI of the INVITE or REGISTER as the realm value
 in the challenge
+
+### Use precomputed hashed passwords, instead of plaintext
+Your password database can store passwords in plain text or as precomputed hashes. Using precomputed hashes adds a layer of security to your application. In order to use precomputed hashes, they should be stored according to RFC2617, using `MD5( username ":" realm ":" password )`. To enable this functionality `passwordLookup()` should return an object like this `{ha1: "YOUR_HASHED_PASSWORD"}`
+
+```js
+const challenge = digestAuth({
+  realm: 'sip.drachtio.org',
+  passwordLookup: function(username, realm, callback) {
+    // ..lookup hashed password for username in realm
+    return callback(null, {ha1: "YOUR_HASHED_PASSWORD"}) ;
+  }
+}) ;
+```

--- a/lib/digest.js
+++ b/lib/digest.js
@@ -70,7 +70,6 @@ function digest(opts) {
     }
 
     const auth = req.authorization;
-    console.log(auth)
     passwordLookup(auth.username, auth.realm, (err, password) => {
       if (err) {
         const nonceValue = nonce() ;

--- a/lib/digest.js
+++ b/lib/digest.js
@@ -70,6 +70,7 @@ function digest(opts) {
     }
 
     const auth = req.authorization;
+    console.log(auth)
     passwordLookup(auth.username, auth.realm, (err, password) => {
       if (err) {
         const nonceValue = nonce() ;
@@ -79,15 +80,21 @@ function digest(opts) {
         debug(`Unknown user: ${auth.username}`);
         return res.send(403);
       }
-      debug(`password returned: ${password}, authorization header: ${JSON.stringify(auth)}`);
+      debug(`password returned: ${JSON.stringify(password)}, authorization header: ${JSON.stringify(auth)}`);
 
-      const ha1 = createHash('md5');
-      ha1.update([auth.username, auth.realm, password].join(':'));
+      let ha1_string;
+      if (password && password.ha1) {
+        ha1_string = password.ha1;
+      } else {
+        const ha1 = createHash('md5');
+        ha1.update([auth.username, auth.realm, password].join(':'));
+        ha1_string = ha1.digest('hex');
+      }
       const ha2 = createHash('md5');
       ha2.update([req.method, auth.uri].join(':'));
       const response = createHash('md5');
       const responseParams = [
-        ha1.digest('hex'),
+        ha1_string,
         auth.nonce
       ];
 


### PR DESCRIPTION
This PR allows a password database to store precomputed ha1 hashes, instead of plain text passwords.